### PR TITLE
Refactor/add resume fields

### DIFF
--- a/prisma/migrations/20250716052645_add_complete_resume_system/migration.sql
+++ b/prisma/migrations/20250716052645_add_complete_resume_system/migration.sql
@@ -1,0 +1,134 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `expectedGradDate` on the `Education` table. All the data in the column will be lost.
+  - The `achievements` column on the `Experience` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `achievements` column on the `Project` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Made the column `startDate` on table `Education` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `endDate` on table `Education` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `location` on table `Experience` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Education" DROP COLUMN "expectedGradDate",
+ALTER COLUMN "startDate" SET NOT NULL,
+ALTER COLUMN "endDate" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Experience" ALTER COLUMN "location" SET NOT NULL,
+DROP COLUMN "achievements",
+ADD COLUMN     "achievements" TEXT[];
+
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "achievements",
+ADD COLUMN     "achievements" TEXT[];
+
+-- CreateTable
+CREATE TABLE "Template" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+
+    CONSTRAINT "Template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Resume" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "resumeName" TEXT NOT NULL,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phoneNumber" TEXT,
+    "website" TEXT,
+    "linkedinUrl" TEXT,
+    "githubUrl" TEXT,
+
+    CONSTRAINT "Resume_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ResumeEducation" (
+    "id" TEXT NOT NULL,
+    "resumeId" TEXT NOT NULL,
+    "institution" TEXT NOT NULL,
+    "degree" TEXT NOT NULL,
+    "isAttending" BOOLEAN NOT NULL DEFAULT false,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "gpa" TEXT,
+    "awards" TEXT,
+    "coursework" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ResumeEducation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ResumeExperience" (
+    "id" TEXT NOT NULL,
+    "resumeId" TEXT NOT NULL,
+    "company" TEXT NOT NULL,
+    "jobTitle" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "isCurrentJob" BOOLEAN NOT NULL DEFAULT false,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "achievements" TEXT[],
+    "technologies" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ResumeExperience_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ResumeProject" (
+    "id" TEXT NOT NULL,
+    "resumeId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "url" TEXT,
+    "achievements" TEXT[],
+    "technologies" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ResumeProject_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ResumeSkills" (
+    "id" TEXT NOT NULL,
+    "resumeId" TEXT NOT NULL,
+    "languages" TEXT,
+    "frameworks" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ResumeSkills_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResumeSkills_resumeId_key" ON "ResumeSkills"("resumeId");
+
+-- AddForeignKey
+ALTER TABLE "Resume" ADD CONSTRAINT "Resume_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "UserProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Resume" ADD CONSTRAINT "Resume_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "Template"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResumeEducation" ADD CONSTRAINT "ResumeEducation_resumeId_fkey" FOREIGN KEY ("resumeId") REFERENCES "Resume"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResumeExperience" ADD CONSTRAINT "ResumeExperience_resumeId_fkey" FOREIGN KEY ("resumeId") REFERENCES "Resume"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResumeProject" ADD CONSTRAINT "ResumeProject_resumeId_fkey" FOREIGN KEY ("resumeId") REFERENCES "Resume"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResumeSkills" ADD CONSTRAINT "ResumeSkills_resumeId_fkey" FOREIGN KEY ("resumeId") REFERENCES "Resume"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,9 +61,9 @@ model UserProfile {
   education   Education[]
   experience  Experience[]
   projects    Project[]
+  resume      Resume[]
   skills      Skills?
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
-  resume      Resume[]
 }
 
 model Education {
@@ -91,10 +91,10 @@ model Experience {
   isCurrentJob Boolean     @default(false)
   startDate    DateTime
   endDate      DateTime?
-  achievements String[]
   technologies String?
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
+  achievements String[]
   profile      UserProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -104,10 +104,10 @@ model Project {
   name         String
   description  String
   url          String?
-  achievements String[]
   technologies String?
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
+  achievements String[]
   profile      UserProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
@@ -129,15 +129,23 @@ model Template {
 }
 
 model Resume {
-  id         String             @id @default(cuid())
-  templateId String
-  profileId  String
-  education  ResumeEducation[]
-  experience ResumeExperience[]
-  projects   ResumeProject[]
-  skills     ResumeSkills?
-  profile    UserProfile        @relation(fields: [profileId], references: [id], onDelete: Cascade)
-  template   Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  id          String             @id @default(cuid())
+  templateId  String
+  profileId   String
+  resumeName  String
+  firstName   String
+  lastName    String
+  email       String
+  phoneNumber String?
+  website     String?
+  linkedinUrl String?
+  githubUrl   String?
+  profile     UserProfile        @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  template    Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  education   ResumeEducation[]
+  experience  ResumeExperience[]
+  projects    ResumeProject[]
+  skills      ResumeSkills?
 }
 
 model ResumeEducation {

--- a/src/app/_components/onboarding/types.ts
+++ b/src/app/_components/onboarding/types.ts
@@ -119,17 +119,21 @@ export const templateSchema = z.object({
   description: z.string(),
 });
 
-export const resumeProfileSchema = z.object({
-  firstName: z.string(),
-  lastName: z.string(),
-});
-
+// For getting list of resumes, for each resume
+// api returns direct personal fields and template data
 export const resumeSchema = z.object({
   id: z.string(),
   templateId: z.string(),
   profileId: z.string(),
+  resumeName: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  phoneNumber: z.string().optional(),
+  website: z.string().optional(),
+  linkedinUrl: z.string().optional(),
+  githubUrl: z.string().optional(),
   template: templateSchema,
-  profile: resumeProfileSchema,
 });
 
 // Resume database models (different from form schemas)
@@ -177,18 +181,17 @@ export const resumeSkillsSchema = z.object({
 });
 
 // Complete resume with all relations
-export const fullResumeSchema = resumeSchema.extend({
+export const completeResumeSchema = resumeSchema.extend({
   education: z.array(resumeEducationSchema),
   experience: z.array(resumeExperienceSchema),
   projects: z.array(resumeProjectSchema),
   skills: resumeSkillsSchema.optional(),
 });
 
+// Used for return type of getResumes, where Resume only requires
+// fields form resumeSchema
 export type Resume = z.infer<typeof resumeSchema>;
-export type FullResume = z.infer<typeof fullResumeSchema>;
-export type Template = z.infer<typeof templateSchema>;
-export type ResumeProfile = z.infer<typeof resumeProfileSchema>;
-export type ResumeEducation = z.infer<typeof resumeEducationSchema>;
-export type ResumeExperience = z.infer<typeof resumeExperienceSchema>;
-export type ResumeProject = z.infer<typeof resumeProjectSchema>;
-export type ResumeSkills = z.infer<typeof resumeSkillsSchema>;
+
+// Possibly used for return type from the getResume, where whole resumeSchema
+// is necessary, for clearer type definition/safety
+export type ResumeFormData = z.infer<typeof completeResumeSchema>;

--- a/src/app/profile/edit/_components/EditProfilePageClient.tsx
+++ b/src/app/profile/edit/_components/EditProfilePageClient.tsx
@@ -10,7 +10,7 @@ import { useMemo } from "react";
 import { OnboardingForm } from "~/app/_components/onboarding/OnboardingForm";
 
 import { ErrorMessage } from "~/components/error-message";
-import { convertToFormData } from "~/lib/profile";
+import { convertProfileToOnboardingForm } from "~/lib/profile";
 
 export function EditProfilePageClient() {
   const router = useRouter();
@@ -29,7 +29,7 @@ export function EditProfilePageClient() {
   };
 
   const initialData = useMemo(
-    () => convertToFormData(profileData),
+    () => convertProfileToOnboardingForm(profileData),
     [profileData],
   );
 

--- a/src/app/resume/builder/_components/ResumeBuilderClient.tsx
+++ b/src/app/resume/builder/_components/ResumeBuilderClient.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams, useParams } from "next/navigation";
-import { convertToFormData } from "~/lib/profile";
+import {
+  convertResumeToFormData,
+  convertProfileToResumeFormData,
+} from "~/lib/profile";
 import { notifyToaster as notify } from "~/lib/notification";
 import { api } from "~/trpc/react";
 import { ResumeForm } from "./ResumeForm";
@@ -11,6 +14,8 @@ import { ResumePreview } from "./ResumePreview";
 import { Download, Save } from "lucide-react";
 import { Toaster } from "react-hot-toast";
 import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
 import { ErrorMessage } from "~/components/error-message";
 import { Header } from "~/components/layout";
 import { LoadingSpinner } from "~/components/ui/loading-spinner";
@@ -23,6 +28,7 @@ export function ResumeBuilderClient() {
   const templateId = searchParams.get("template");
   const resumeId = (params.id as string) || undefined; // From resume/builder/[id]
   const [formData, setFormData] = useState<OnboardingFormData | null>(null);
+  const [resumeName, setResumeName] = useState<string>("");
 
   /*
    * Since Resume Builder is used for creation and edit
@@ -40,7 +46,7 @@ export function ResumeBuilderClient() {
 
   // Fetch existing resume data if editing
   const {
-    data: existingResume,
+    data: resumeData,
     isLoading: resumeLoading,
     error: resumeError,
   } = api.resume.getResume.useQuery(
@@ -53,11 +59,10 @@ export function ResumeBuilderClient() {
       },
     },
   );
-
   // Prioritize the templateId to follow parameters
   // When new resume, we follow templateId from params
   // When editing resume, we follow saved templateId in resume data
-  const effectiveTemplateId = templateId ?? existingResume?.templateId;
+  const effectiveTemplateId = templateId ?? resumeData?.templateId;
 
   // ======================== Toaster Notification Function ====================
 
@@ -67,12 +72,14 @@ export function ResumeBuilderClient() {
 
   const handleSaveResume = useCallback(async () => {
     // Do nothing if there is no formdata or no templateid
-    if (!formData || !effectiveTemplateId) return;
+    if (!formData || !effectiveTemplateId || !resumeName) return;
 
     try {
       const result = await saveResume.mutateAsync({
-        formData,
+        formData: formData,
         templateId: effectiveTemplateId,
+        resumeName: resumeName,
+        personalDetails: formData.personalDetails,
         resumeId: resumeId ?? undefined,
       });
 
@@ -107,7 +114,15 @@ export function ResumeBuilderClient() {
       console.error("Save failed: ", error);
       notify(false, "Error saving resume!", 2500);
     }
-  }, [formData, saveResume, isEditMode, effectiveTemplateId, resumeId, utils]);
+  }, [
+    formData,
+    resumeName,
+    saveResume,
+    isEditMode,
+    effectiveTemplateId,
+    resumeId,
+    utils,
+  ]);
 
   // ============================= PDF Export functionality ========================
   const exportPDF = api.resume.exportLivePDF.useMutation();
@@ -136,9 +151,12 @@ export function ResumeBuilderClient() {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
+
+      notify(true, "PDF download started.", 1500);
     } catch (error) {
       console.error("PDF download failed:", error);
       // Add toast notification here
+      notify(false, "PDF download failed.", 2500);
     }
   }, [formData, effectiveTemplateId, exportPDF]);
 
@@ -149,58 +167,47 @@ export function ResumeBuilderClient() {
     setFormData(data);
   }, []);
 
+  // If editing, use existing resume data, otherwise use profile
   useEffect(() => {
-    // If editing, use existing resume data, otherwise use profile
-    if (isEditMode && existingResume) {
-      // Transform resume data to match profile structure for convertToFormData
-      const resumeAsProfileData = {
-        ...existingResume.profile,
-        education: existingResume.education.map((edu) => ({
-          ...edu,
-          profileId: existingResume.profile.id,
-        })),
-        experience: existingResume.experience.map((exp) => ({
-          ...exp,
-          profileId: existingResume.profile.id,
-        })),
-        projects: existingResume.projects.map((proj) => ({
-          ...proj,
-          profileId: existingResume.profile.id,
-        })),
-        skills: existingResume.skills
-          ? {
-              ...existingResume.skills,
-              profileId: existingResume.profile.id,
-              languages: existingResume.skills.languages ?? null,
-              frameworks: existingResume.skills.frameworks ?? null,
-            }
-          : null,
-      };
-
-      const resumeFormData = convertToFormData(resumeAsProfileData);
-      if (resumeFormData) {
-        setFormData(resumeFormData);
+    if (isEditMode && resumeData) {
+      const convertedData = convertResumeToFormData(resumeData);
+      if (convertedData) {
+        setFormData({
+          personalDetails: convertedData.personalDetails,
+          education: convertedData.education,
+          experience: convertedData.experience,
+          projects: convertedData.projects,
+          skills: convertedData.skills,
+        });
+        setResumeName(convertedData.resumeName);
       }
     } else if (profile) {
-      const initialData = convertToFormData(profile);
+      const initialData = convertProfileToResumeFormData(profile);
       if (initialData) {
-        setFormData(initialData);
+        setFormData({
+          personalDetails: initialData.personalDetails,
+          education: initialData.education,
+          experience: initialData.experience,
+          projects: initialData.projects,
+          skills: initialData.skills,
+        });
+        setResumeName(initialData.resumeName);
       }
     }
-  }, [profile, existingResume, isEditMode]);
+  }, [profile, resumeData, isEditMode]);
 
   // Sync URL Template
   useEffect(() => {
-    if (isEditMode && existingResume?.templateId && !templateId) {
+    if (isEditMode && resumeData?.templateId && !templateId) {
       // Update the current url to include the template parameter
       const currentUrl = new URL(window.location.href);
-      currentUrl.searchParams.set("template", existingResume.templateId);
+      currentUrl.searchParams.set("template", resumeData.templateId);
       // Do not reload/re-render page for optimizaation (when switching templates)
       // back button will go back to previous page instead of allowing re-save
       // updates only
       window.history.replaceState({}, "", currentUrl.toString());
     }
-  });
+  }, [isEditMode, resumeData?.templateId, templateId]);
 
   if (profileLoading || (resumeId && resumeLoading)) {
     return (
@@ -278,7 +285,10 @@ export function ResumeBuilderClient() {
             <Button
               onClick={handleSaveResume}
               disabled={
-                !formData || !effectiveTemplateId || saveResume.isPending
+                !formData ||
+                !effectiveTemplateId ||
+                !resumeName ||
+                saveResume.isPending
               }
               variant="outline"
               size="sm"
@@ -306,6 +316,23 @@ export function ResumeBuilderClient() {
         <div className="flex h-[calc(100vh-240px)] gap-8">
           {/* Left Panel - Form */}
           <div className="w-1/2 overflow-auto rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+            {/* Resume Name Input */}
+            <div className="mb-6">
+              <Label
+                htmlFor="resumeName"
+                className="text-sm font-medium text-slate-700 dark:text-slate-300"
+              >
+                Resume Name
+              </Label>
+              <Input
+                id="resumeName"
+                value={resumeName}
+                onChange={(e) => setResumeName(e.target.value)}
+                placeholder="Enter resume name"
+                className="mt-1"
+              />
+            </div>
+
             {formData && (
               <ResumeForm
                 initialData={formData}

--- a/src/app/resume/builder/_components/ResumeBuilderClient.tsx
+++ b/src/app/resume/builder/_components/ResumeBuilderClient.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams, useParams } from "next/navigation";
 import {
-  convertResumeToFormData,
-  convertProfileToResumeFormData,
+  convertResumeToBuilderForm,
+  convertProfileToBuilderForm,
 } from "~/lib/profile";
 import { notifyToaster as notify } from "~/lib/notification";
 import { api } from "~/trpc/react";
@@ -170,7 +170,7 @@ export function ResumeBuilderClient() {
   // If editing, use existing resume data, otherwise use profile
   useEffect(() => {
     if (isEditMode && resumeData) {
-      const convertedData = convertResumeToFormData(resumeData);
+      const convertedData = convertResumeToBuilderForm(resumeData);
       if (convertedData) {
         setFormData({
           personalDetails: convertedData.personalDetails,
@@ -182,7 +182,7 @@ export function ResumeBuilderClient() {
         setResumeName(convertedData.resumeName);
       }
     } else if (profile) {
-      const initialData = convertProfileToResumeFormData(profile);
+      const initialData = convertProfileToBuilderForm(profile);
       if (initialData) {
         setFormData({
           personalDetails: initialData.personalDetails,

--- a/src/app/resume/list/_components/ResumeCard.tsx
+++ b/src/app/resume/list/_components/ResumeCard.tsx
@@ -34,10 +34,6 @@ export function ResumeCard({ resume }: ResumeCardProps) {
     // router.push(`/resume/view/${resume.id}`);
   };
 
-  const resumeTitle = resume.profile
-    ? `${resume.profile.firstName} ${resume.profile.lastName}'s Resume`
-    : `Resume (${resume.template.name})`;
-
   const handleDelete = useCallback(async () => {
     if (!resume.id) return;
 
@@ -63,7 +59,7 @@ export function ResumeCard({ resume }: ResumeCardProps) {
         <div className="flex items-start justify-between">
           <div className="flex-1">
             <h3 className="font-semibold text-slate-900 dark:text-white">
-              {resumeTitle}
+              {resume.resumeName}
             </h3>
             <p className="text-sm text-slate-600 dark:text-slate-400">
               {resume.template.name} Template

--- a/src/app/resume/list/_components/ResumeListClient.tsx
+++ b/src/app/resume/list/_components/ResumeListClient.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { api } from "~/trpc/react";
 import { ResumeCard } from "./ResumeCard";
 import { EmptyState } from "./EmptyState";
-import { convertToResumeListData } from "~/lib/profile";
+import { convertResumesToList } from "~/lib/profile";
 
 import { Plus } from "lucide-react";
 import { ErrorMessage } from "~/components/error-message";
@@ -20,7 +20,7 @@ export function ResumeListClient() {
     error,
   } = api.resume.getResumes.useQuery();
 
-  const resumes = convertToResumeListData(resumesData);
+  const resumes = convertResumesToList(resumesData);
 
   if (isLoading) {
     return (

--- a/src/app/resume/list/_components/ResumeListClient.tsx
+++ b/src/app/resume/list/_components/ResumeListClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { api } from "~/trpc/react";
 import { ResumeCard } from "./ResumeCard";
 import { EmptyState } from "./EmptyState";
+import { convertToResumeListData } from "~/lib/profile";
 
 import { Plus } from "lucide-react";
 import { ErrorMessage } from "~/components/error-message";
@@ -13,7 +14,13 @@ import { LoadingSpinner } from "~/components/ui/loading-spinner";
 import { Toaster } from "react-hot-toast";
 
 export function ResumeListClient() {
-  const { data: resumes, isLoading, error } = api.resume.getResumes.useQuery();
+  const {
+    data: resumesData,
+    isLoading,
+    error,
+  } = api.resume.getResumes.useQuery();
+
+  const resumes = convertToResumeListData(resumesData);
 
   if (isLoading) {
     return (

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -10,7 +10,7 @@ import type {
   GetResumesData,
 } from "~/server/api/routers/types";
 
-export const convertToFormData = (
+export const convertProfileToOnboardingForm = (
   profileData: GetProfileData | null | undefined,
 ): OnboardingFormData | undefined => {
   if (!profileData) return undefined;
@@ -107,7 +107,7 @@ export const formatDataForTypst = (formData: OnboardingFormData) => {
   };
 };
 
-export const convertToResumeFormData = (
+export const convertResumeToDisplayForm = (
   resumeData: GetResumeData | null | undefined,
 ): ResumeFormData | undefined => {
   if (!resumeData) return undefined;
@@ -156,7 +156,7 @@ export const convertToResumeFormData = (
   };
 };
 
-export const convertToResumeListData = (
+export const convertResumesToList = (
   resumesData: GetResumesData | null | undefined,
 ): Resume[] => {
   if (!resumesData) return [];
@@ -172,14 +172,14 @@ export const convertToResumeListData = (
 };
 
 // Helper function to convert resume data to ResumeBuilderFormData
-export const convertResumeToFormData = (
+export const convertResumeToBuilderForm = (
   resumeData: GetResumeData | null | undefined,
 ):
   | (OnboardingFormData & { resumeName: string; templateId: string })
   | undefined => {
   if (!resumeData) return undefined;
 
-  const converted = convertToResumeFormData(resumeData);
+  const converted = convertResumeToDisplayForm(resumeData);
   if (!converted) return undefined;
 
   return {
@@ -202,7 +202,7 @@ export const convertResumeToFormData = (
 };
 
 // Helper function to convert profile data to ResumeBuilderFormData with default resume name
-export const convertProfileToResumeFormData = (
+export const convertProfileToBuilderForm = (
   profileData: GetProfileData | null | undefined,
   templateId?: string,
 ):
@@ -210,7 +210,7 @@ export const convertProfileToResumeFormData = (
   | undefined => {
   if (!profileData) return undefined;
 
-  const converted = convertToFormData(profileData);
+  const converted = convertProfileToOnboardingForm(profileData);
   if (!converted) return undefined;
 
   return {

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,6 +1,14 @@
 import type { Education, Experience, Project } from "@prisma/client";
-import type { OnboardingFormData } from "~/app/_components/onboarding/types";
-import type { GetProfileData } from "~/server/api/routers/types";
+import type {
+  OnboardingFormData,
+  ResumeFormData,
+  Resume,
+} from "~/app/_components/onboarding/types";
+import type {
+  GetProfileData,
+  GetResumeData,
+  GetResumesData,
+} from "~/server/api/routers/types";
 
 export const convertToFormData = (
   profileData: GetProfileData | null | undefined,
@@ -96,5 +104,118 @@ export const formatDataForTypst = (formData: OnboardingFormData) => {
       endDate: exp.endDate ? formatDate(exp.endDate) : undefined,
     })),
     projects: validProjects,
+  };
+};
+
+export const convertToResumeFormData = (
+  resumeData: GetResumeData | null | undefined,
+): ResumeFormData | undefined => {
+  if (!resumeData) return undefined;
+
+  return {
+    ...resumeData,
+    // Convert null to undefined for optional personal fields
+    phoneNumber: resumeData.phoneNumber ?? undefined,
+    website: resumeData.website ?? undefined,
+    linkedinUrl: resumeData.linkedinUrl ?? undefined,
+    githubUrl: resumeData.githubUrl ?? undefined,
+
+    // Convert education relation
+    education:
+      resumeData.education?.map((edu) => ({
+        ...edu,
+        gpa: edu.gpa ?? undefined,
+        awards: edu.awards ?? undefined,
+        coursework: edu.coursework ?? undefined,
+      })) ?? [],
+
+    // Convert experience relation
+    experience:
+      resumeData.experience?.map((exp) => ({
+        ...exp,
+        endDate: exp.endDate ?? undefined,
+        technologies: exp.technologies ?? undefined,
+      })) ?? [],
+
+    // Convert projects relation
+    projects:
+      resumeData.projects?.map((proj) => ({
+        ...proj,
+        url: proj.url ?? undefined,
+        technologies: proj.technologies ?? undefined,
+      })) ?? [],
+
+    // Convert skills relation
+    skills: resumeData.skills
+      ? {
+          ...resumeData.skills,
+          languages: resumeData.skills.languages ?? undefined,
+          frameworks: resumeData.skills.frameworks ?? undefined,
+        }
+      : undefined,
+  };
+};
+
+export const convertToResumeListData = (
+  resumesData: GetResumesData | null | undefined,
+): Resume[] => {
+  if (!resumesData) return [];
+
+  return resumesData.map((resume) => ({
+    ...resume,
+    // Convert null to undefined for optional personal fields
+    phoneNumber: resume.phoneNumber ?? undefined,
+    website: resume.website ?? undefined,
+    linkedinUrl: resume.linkedinUrl ?? undefined,
+    githubUrl: resume.githubUrl ?? undefined,
+  }));
+};
+
+// Helper function to convert resume data to ResumeBuilderFormData
+export const convertResumeToFormData = (
+  resumeData: GetResumeData | null | undefined,
+):
+  | (OnboardingFormData & { resumeName: string; templateId: string })
+  | undefined => {
+  if (!resumeData) return undefined;
+
+  const converted = convertToResumeFormData(resumeData);
+  if (!converted) return undefined;
+
+  return {
+    personalDetails: {
+      firstName: converted.firstName,
+      lastName: converted.lastName,
+      email: converted.email,
+      phoneNumber: converted.phoneNumber ?? "",
+      website: converted.website ?? "",
+      linkedinUrl: converted.linkedinUrl ?? "",
+      githubUrl: converted.githubUrl ?? "",
+    },
+    education: converted.education,
+    experience: converted.experience,
+    projects: converted.projects,
+    skills: converted.skills,
+    resumeName: converted.resumeName,
+    templateId: converted.templateId,
+  };
+};
+
+// Helper function to convert profile data to ResumeBuilderFormData with default resume name
+export const convertProfileToResumeFormData = (
+  profileData: GetProfileData | null | undefined,
+  templateId?: string,
+):
+  | (OnboardingFormData & { resumeName: string; templateId?: string })
+  | undefined => {
+  if (!profileData) return undefined;
+
+  const converted = convertToFormData(profileData);
+  if (!converted) return undefined;
+
+  return {
+    ...converted,
+    resumeName: `${profileData.firstName} ${profileData.lastName}'s Resume`,
+    templateId: templateId,
   };
 };

--- a/src/server/api/routers/types.ts
+++ b/src/server/api/routers/types.ts
@@ -1,5 +1,12 @@
 import { type onboardingRouter } from "./onboarding";
+import { type resumeRouter } from "./resume";
 
 export type GetProfileData = Awaited<
   ReturnType<typeof onboardingRouter.getProfile>
+>;
+
+export type GetResumeData = Awaited<ReturnType<typeof resumeRouter.getResume>>;
+
+export type GetResumesData = Awaited<
+  ReturnType<typeof resumeRouter.getResumes>
 >;

--- a/tests/unit/lib/profile.test.ts
+++ b/tests/unit/lib/profile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertToFormData } from '../../../src/lib/profile';
+import { convertProfileToOnboardingForm } from '../../../src/lib/profile';
 import type { GetProfileData } from '../../../src/server/api/routers/types';
 
 // Mock data generator for testing
@@ -66,15 +66,15 @@ const createMockProfileData = (overrides: Partial<GetProfileData> = {}): GetProf
   ...overrides,
 });
 
-describe('convertToFormData', () => {
+describe('convertProfileToOnboardingForm', () => {
   it('returns undefined when profileData is null or undefined', () => {
-    expect(convertToFormData(null)).toBeUndefined();
-    expect(convertToFormData(undefined)).toBeUndefined();
+    expect(convertProfileToOnboardingForm(null)).toBeUndefined();
+    expect(convertProfileToOnboardingForm(undefined)).toBeUndefined();
   });
 
   it('converts complete profile data to form data structure', () => {
     const mockData = createMockProfileData();
-    const result = convertToFormData(mockData);
+    const result = convertProfileToOnboardingForm(mockData);
 
     expect(result).toEqual({
       personalDetails: {
@@ -134,7 +134,7 @@ describe('convertToFormData', () => {
       githubUrl: null,
     });
     
-    const result = convertToFormData(mockData);
+    const result = convertProfileToOnboardingForm(mockData);
 
     expect(result?.personalDetails).toEqual({
       firstName: 'John',
@@ -154,7 +154,7 @@ describe('convertToFormData', () => {
       projects: undefined,
     });
     
-    const result = convertToFormData(mockData);
+    const result = convertProfileToOnboardingForm(mockData);
 
     expect(result?.education).toEqual([]);
     expect(result?.experience).toEqual([]);


### PR DESCRIPTION
- Added new fields for the resume model to allow modification of personal details
- Added additional form input (metadata) for resume name for greater UX when viewing list of resumes created under profile
- Created new helper functions for data structure mapping between react query (with tRPC) and the react components to streamline typing. 
- Renamed functions to be more developer friendly.
- **Added prisma migration for database migration** \*

* Realised that we still needed to run `npx prisma migrate dev` to generate the migration history for db migration. My apologies, this was not known to me until the latest database changes. PR #19 and branch db/add-resume-model did not have this migration. Lesson learn T.T